### PR TITLE
Allow menus to be null and fix up menu_name lookup where term was not…

### DIFF
--- a/stanford_subsites.inc
+++ b/stanford_subsites.inc
@@ -624,7 +624,7 @@ function stanford_subsites_get_subsite_term_from_node($node) {
   }
 
   $lang = LANGUAGE_NONE;
-  $tid = @$node->{SUBSITE_TAGS_FIELD}[$lang][0]['tid'];
+  $tid = $node->{SUBSITE_TAGS_FIELD}[$lang][0]['tid'];
 
   if (!$tid) {
     return FALSE;
@@ -633,14 +633,14 @@ function stanford_subsites_get_subsite_term_from_node($node) {
   // old way that ends up calling entity_load
   //return taxonomy_term_load($tid);
 
-  // Using entity field query
-  $query = new EntityFieldQuery();
-  $result = $query
-  ->entityCondition('entity_type', 'taxonomy_term')
-  ->propertyCondition('vid', (int) $node->vid, '=')
-  ->execute();
-  return $result['taxonomy_term'];
+  $query = db_select("taxonomy_term_data", "ttd")
+            ->fields("ttd")
+            ->condition("tid", $tid)
+            ->execute();
 
+  $term = $query->fetchObject();
+
+  return $term;
 }
 
 /**

--- a/stanford_subsites.install
+++ b/stanford_subsites.install
@@ -52,6 +52,7 @@ function stanford_subsites_schema() {
     ),
     'indexes' => array(
       'ntm' => array('nid', "tid", "menu"),
+      'nt' => array('nid', "tid"),
       'nm' => array('nid', "menu"),
       'tm' => array("tid", "menu"),
     ),

--- a/stanford_subsites.install
+++ b/stanford_subsites.install
@@ -33,7 +33,6 @@ function stanford_subsites_schema() {
         'description' => 'Subsite menu name',
         'type' => 'varchar',
         'length' => 255,
-        'not null' => TRUE,
         'default' => '',
       ),
       'context' => array(
@@ -53,13 +52,11 @@ function stanford_subsites_schema() {
     ),
     'indexes' => array(
       'ntm' => array('nid', "tid", "menu"),
-      'nt' => array('nid', "tid"),
       'nm' => array('nid', "menu"),
       'tm' => array("tid", "menu"),
     ),
     'unique keys' => array(
       'tid' => array('tid'),
-      'menu' => array('menu'),
       'machine_name' => array('machine_name'),
     ),
     'primary key' => array('nid'),
@@ -100,4 +97,29 @@ function stanford_subsites_update_7201(&$sandbox) {
     $name = str_replace("-", "_", $name);
     stanford_subsite_index_update($result->nid, NULL, NULL, NULL, $name);
   }
+}
+
+/**
+ * Updates database schema
+ */
+function stanford_subsites_update_7300(&$sandbox) {
+
+  // Allow menu to be null.
+  $table = "subsite_index";
+  $field = "menu";
+  $field_new = "menu";
+  $spec = array(
+    'description' => 'Subsite menu name',
+    'type' => 'varchar',
+    'length' => 255,
+    'default' => '',
+  );
+  $keys_new = array();
+
+  // Do eet!
+  db_change_field($table, $field, $field_new, $spec, $keys_new);
+
+  // Keys.
+  db_drop_unique_key("subsite_index", "menu");
+
 }


### PR DESCRIPTION
… being returned

How to test:
1. Install the current 7.x-3.x branch on a JSA website
2. Enable and create a subsite
3. Create a second subsite and it should PDO error out
4. Check out this branch
5. run drush updb -y
6. Try to create a third subsite and it should be successful.

@josephgknox FYI
